### PR TITLE
Have Makefiles respect environment CFLAGS/LDFLAGS

### DIFF
--- a/_Projects_/ps3netsrv/Makefile
+++ b/_Projects_/ps3netsrv/Makefile
@@ -3,8 +3,8 @@ BUILD_TYPE = release
 
 OUTPUT := ps3netsrv
 OBJS=main.o compat.o File.o VIsoFile.o
-CFLAGS=-Wall -I. -std=gnu99 -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
-LDFLAGS=-L. 
+CFLAGS+=-Wall -I. -std=gnu99 -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+LDFLAGS+=-L. 
 LIBS = -lstdc++
 
 ifeq ($(OS), linux)

--- a/_Projects_/ps3netsrv/Makefile.linux
+++ b/_Projects_/ps3netsrv/Makefile.linux
@@ -3,8 +3,8 @@ BUILD_TYPE = release
 
 OUTPUT := ps3netsrv
 OBJS=main.o compat.o File.o VIsoFile.o
-CFLAGS=-Wall -I. -std=gnu99 -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
-LDFLAGS=-L. 
+CFLAGS+=-Wall -I. -std=gnu99 -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+LDFLAGS+=-L. 
 LIBS = -lstdc++
 
 ifeq ($(OS), linux)


### PR DESCRIPTION
Currently, Makefiles start by discarding any environment initial value for CFLAGS and LDFLAGS which is not the preferable way for certain systems like Gentoo, which handle those flags in their build system.

This change just appends flags to variables instead of fully replacing them so user ones can be set and used along with the needed ones.