### PR TITLE
Fix endianess

### DIFF
--- a/_Projects_/ps3netsrv/Makefile
+++ b/_Projects_/ps3netsrv/Makefile
@@ -19,6 +19,8 @@ LIBS += -lpthread
 endif
 
 ifeq ($(OS), windows)
+CFLAGS += -D_OS_WINDOWS
+CPPFLAGS += -D_OS_WINDOWS
 OBJS += src/scandir.o src/dirent.o
 CC = gcc
 CXX = g++

--- a/_Projects_/ps3netsrv/include/common.h
+++ b/_Projects_/ps3netsrv/include/common.h
@@ -10,7 +10,12 @@
 #define DPRINTF(...)
 #endif
 
-#ifdef __BIG_ENDIAN__
+#ifndef _OS_WINDOWS
+#include <endian.h>
+#define __BIG_ENDIAN__ (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#endif
+
+#if __BIG_ENDIAN__
 
 static inline uint16_t BE16(uint16_t x)
 {


### PR DESCRIPTION
Was not working properly on mips devices (tried on tp-link Archer C7 v5, not showing files, and debugging, show "unknown command"). I tested this solution on Ubuntu, Windows and OpenWrt (mips_24kc) device. I didn't test it on macOS cause I didn't have one.