### PR TITLE
Fix Webman not ready #342

### DIFF
--- a/main.c
+++ b/main.c
@@ -492,7 +492,7 @@ static void wwwd_thread(u64 arg)
 	restoreAutoPowerOff();
 	#endif
 
-	if(cobra_version >= 0x0800) sys_ppu_thread_sleep(2); // wait 2 seconds on cobra 8.x for network
+	if(cobra_version >= 0x0800) sys_ppu_thread_sleep(3); // wait 3 seconds on cobra 8.x for network
 
 	if(!webman_config->ftpd)
 		sys_ppu_thread_create(&thread_id_ftpd, ftpd_thread, NULL, THREAD_PRIO, THREAD_STACK_SIZE_FTP_SERVER, SYS_PPU_THREAD_CREATE_JOINABLE, THREAD_NAME_FTP); // start ftp daemon immediately


### PR DESCRIPTION
It seems that when webMan mod is running on an SSD the wait time for cobra is not enough.
