### PR TITLE
ps3netsrv - Fixed broken meson build by adding Console.cpp to meson.build

### DIFF
--- a/_Projects_/ps3netsrv/meson.build
+++ b/_Projects_/ps3netsrv/meson.build
@@ -13,7 +13,8 @@ ps3netsrv_src = files(
   'src/compat.c',
   'src/File.cpp',
   'src/main.cpp',
-  'src/VIsoFile.cpp'
+  'src/VIsoFile.cpp',
+  'src/Console.cpp'
 )
 if host_machine.system() == 'windows'
   ps3netsrv_src += files(


### PR DESCRIPTION
Had to add this because the automated CI job for my Docker image was failing since 3 days.

Please consider also testing the meson build in the future when refactoring stuff @kam821 