### PR TITLE
Disabled CORS for security reasons

### DIFF
--- a/include/html.h
+++ b/include/html.h
@@ -417,7 +417,6 @@ static size_t prepare_header(char *buffer, const char *param, u8 is_binary)
 	bool set_base_path = false;
 
 	size_t slen = sprintf(buffer,	"HTTP/1.1 200 OK\r\n"
-									"Access-Control-Allow-Origin: *\r\n"
 									"Content-Type: "); char *header = buffer + slen;
 
 	int flen = strlen(param);


### PR DESCRIPTION
Cross-Origin Resource Sharing could lead to security problems:
malicious website could scan local network for PS3 w/ Webman-mod webserver
and execute arbitrary code on it. 
Proof of concept: [https://github.com/kotborealis/webman-mod-cors-poc](https://github.com/kotborealis/webman-mod-cors-poc)

![](https://camo.githubusercontent.com/4e2f92cc3bb3d26c67f10183e6f29330efcbd6cda7b5ca6a64f1a5245333ba45/687474703a2f2f697069632e73752f696d672f696d67372f66732f6b6973735f31336b622e313630393637363930392e706e67)