### PR TITLE
Fix ps3netsrv build on MacOS

### DIFF
--- a/_Projects_/ps3netsrv/include/common.h
+++ b/_Projects_/ps3netsrv/include/common.h
@@ -11,7 +11,7 @@
 #endif
 
 #ifndef _OS_WINDOWS
-#include <endian.h>
+#include <sys/types.h>
 #define __BIG_ENDIAN__ (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #endif
 #if __BIG_ENDIAN__


### PR DESCRIPTION
Include <sys/types.h> instead of <endian.h> for *nix systems.