### PR TITLE
[slaunch] Add preliminary support for loading a custom uncompressed ARGB image format.

### DIFF
--- a/_Projects_/slaunch/Makefile
+++ b/_Projects_/slaunch/Makefile
@@ -10,7 +10,7 @@ CRT_HEAD += $(shell ppu-lv2-gcc -print-file-name'='ecrtn.o)
 
 ROOT_PATH = ../..
 
-PPU_SRCS = $(ROOT_PATH)/libc.c mem.c misc.c png_dec.c jpg_dec.c blitting.c slaunch.c
+PPU_SRCS = $(ROOT_PATH)/libc.c mem.c misc.c argb_dec.c png_dec.c jpg_dec.c blitting.c slaunch.c
 PPU_INCDIRS	= -I $(ROOT_PATH)/vsh
 PPU_PRX_TARGET = slaunch.prx
 PPU_PRX_LDFLAGS = -L $(ROOT_PATH)/lib -Wl, --strip-unused-data

--- a/_Projects_/slaunch/argb_dec.c
+++ b/_Projects_/slaunch/argb_dec.c
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2022 Darjan Krijan <krijan@dkmechatronics.eu>
+ *
+ *  Simple custom uncompressed ARGB image format for loading
+ *  covers instantly on SSD.
+ *
+ *  See tools/png2argb.c for converting PNG images to ARGB
+ */
+
+#include <stdio.h>
+#include "include/argb_dec.h"
+#include "include/mem.h"
+#include "include/vsh_exports.h"
+
+const char argb_magic[] = "ARGB";
+
+enum argb_flags {
+	ARGB_FLAG_TRANSPARENCY = 0x1 // image has A values less than 0xFF
+};
+
+// 128 byte header, big-endian values
+typedef struct {
+	char magic[4];        // ASCII "ARGB"
+	uint32_t nx;
+	uint32_t ny;
+	uint32_t flags;       // Used for indicating existing transparent pixels
+	uint8_t padding[112]; // Padding to 128 byte cache line boundary on PS3
+	// uncompressed pixel data following as ARGB (uint32_t)
+} argb_h_t;
+
+/***********************************************************************
+* load argb file
+* file_path = path to argb file e.g. "/dev_hdd0/test.argb"
+***********************************************************************/
+Buffer load_argb(const char *file_path, void* buf_addr)
+{
+	argb_h_t argb_h;
+	FILE *fp;
+
+	Buffer tmp;
+	tmp.addr = (uint32_t*)buf_addr;
+
+	tmp.b = 0; // transparency
+	tmp.w = tmp.h = 0;
+	tmp.x = tmp.y = 0;
+
+	fp = fopen(file_path, "rb");
+	fread(&argb_h, sizeof(uint8_t), sizeof(argb_h_t), fp); // 128 bytes
+
+	if (memcmp(&argb_h.magic, argb_magic, sizeof(uint32_t)) || !argb_h.nx || !argb_h.ny) {
+		fclose(fp);
+		return tmp;
+	}
+
+	tmp.b = argb_h.flags&ARGB_FLAG_TRANSPARENCY;
+
+	fread(buf_addr, sizeof(uint32_t), (size_t)argb_h.nx*(size_t)argb_h.ny, fp);
+	fclose(fp);
+
+	tmp.w = argb_h.nx;
+	tmp.h = argb_h.ny;
+
+	return tmp;
+}

--- a/_Projects_/slaunch/blitting.c
+++ b/_Projects_/slaunch/blitting.c
@@ -1,4 +1,5 @@
 #include "include/blitting.h"
+#include "include/argb_dec.h"
 #include "include/png_dec.h"
 #include "include/jpg_dec.h"
 #include "include/misc.h"
@@ -412,6 +413,8 @@ retry:
 
 	if(strstr((char*)path, ".png") || strstr((char*)path, ".PNG"))
 		ctx.img[idx] = load_png(path, buf);
+	else if(strstr((char*)path, ".argb") || strstr((char*)path, ".ARGB"))
+		ctx.img[idx] = load_argb(path, buf);
 	else
 		ctx.img[idx] = load_jpg(path, buf);
 

--- a/_Projects_/slaunch/include/argb_dec.h
+++ b/_Projects_/slaunch/include/argb_dec.h
@@ -1,0 +1,8 @@
+#ifndef _ARGB_DEC_H_
+#define _ARGB_DEC_H_
+
+#include "blitting.h"
+
+Buffer load_argb(const char *file_path, void* buf_addr);
+
+#endif // _ARGB_DEC_H_

--- a/_Projects_/slaunch/tools/Makefile
+++ b/_Projects_/slaunch/tools/Makefile
@@ -1,0 +1,10 @@
+all: png2argb
+
+png2argb: png2argb.o
+	cc  png2argb.o -lspng -o png2argb
+
+png2argb.o: png2argb.c
+	cc -c png2argb.c
+
+clean:
+	rm png2argb.o png2argb

--- a/_Projects_/slaunch/tools/png2argb.c
+++ b/_Projects_/slaunch/tools/png2argb.c
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (C) 2022 Darjan Krijan <krijan@dkmechatronics.eu>
+ *
+ *  Convert a PNG to a simple uncompressed ARGB image format for slaunch.
+ *  Uses libspng for simplicity and performance reasons.
+ *
+ *  Usage:
+ *  png2argb <png input file> [<argb output file>]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#include <byteswap.h>
+#endif
+
+#include "spng.h"
+
+#define CHECK_OW 0
+
+typedef struct {
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+	uint8_t a;
+} png_px_t;
+
+typedef struct {
+	uint8_t a;
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+} argb_px_t;
+
+enum argb_flags {
+	ARGB_FLAG_TRANSPARENCY = 0x1 // image has A values less than 0xFF
+};
+
+// big-endian values
+typedef struct argb {
+	char magic[4];        // ASCII ARGB
+	uint32_t nx;
+	uint32_t ny;
+	uint32_t flags;       // Used for indicating existing transparent pixels
+	uint8_t padding[112]; // Padding to 128 byte cache line boundary on PS3
+	argb_px_t *px;
+} argb_t;
+
+const char argb_magic[] = "ARGB";
+
+int main(int argc, char *argv[]) {
+	int ret = 0;
+
+	FILE *fp_png;
+	spng_ctx *lsp_ctx = NULL;
+	png_px_t *png_px = NULL;
+
+	uint64_t n;
+	size_t png_px_size;
+
+	argb_t argb = {0};
+	char file_argb[4096] = {0};
+	FILE *fp_argb;
+
+	if (argc < 2) {
+		printf("No input file\n");
+		printf("Usage: %s <png input file> [<argb output file>]\n", argv[0]);
+		printf("Not providing an output file will produce an argb image next to the PNG image.\n", argv[0]);
+
+		return EXIT_FAILURE;
+	} else if (argc > 3) {
+		printf("Too many input arguments\n");
+		printf("Usage: %s <png input file> [<argb output file>]\n", argv[0]);
+		printf("Not providing an output file will produce an argb image next to the PNG image.\n", argv[0]);
+
+		return EXIT_FAILURE;
+	}
+
+	if (!(fp_png = fopen(argv[1], "rb"))) {
+		printf("Error opening input PNG file '%s'\n", argv[1]);
+		return EXIT_FAILURE;
+	}
+
+	if (!(lsp_ctx = spng_ctx_new(0))) {
+		printf("spng_ctx_new() failed\n");
+		return EXIT_FAILURE;
+	}
+
+	spng_set_png_file(lsp_ctx, fp_png);
+
+	struct spng_ihdr ihdr;
+	if (ret = spng_get_ihdr(lsp_ctx, &ihdr)) {
+		printf("spng_get_ihdr() error: %s\n", spng_strerror(ret));
+		return EXIT_FAILURE;
+	}
+
+	if (ihdr.width%4) {
+		printf("Image '%s' doesn't have a width multiple of 4, aborting.\n", argv[1]);
+		return EXIT_FAILURE;
+	} else if (ihdr.height%4) {
+		printf("Image '%s' doesn't have a height multiple of 4, aborting.\n", argv[1]);
+		return EXIT_FAILURE;
+	}
+
+	argb.nx = ihdr.width;
+	argb.ny = ihdr.height;
+	n  = (uint64_t)argb.nx*(uint64_t)argb.ny;
+
+	if (ret = spng_decoded_image_size(lsp_ctx, SPNG_FMT_RGBA8, &png_px_size)) {
+		fprintf(stderr, "spng_decoded_image_size() error: %s\n", spng_strerror(ret));
+		spng_ctx_free(lsp_ctx);
+
+		return EXIT_FAILURE;
+	}
+
+	if (!(png_px = malloc(png_px_size))) {
+		fprintf(stderr, "Error: malloc returned NULL with size %lu\n", png_px_size);
+		spng_ctx_free(lsp_ctx);
+
+		return EXIT_FAILURE;
+	}
+
+	if (ret = spng_decode_image(lsp_ctx, png_px, png_px_size, SPNG_FMT_RGBA8, 0)) {
+		printf("spng_decode_image() error: %s\n", spng_strerror(ret));
+		free(png_px);
+		spng_ctx_free(lsp_ctx);
+
+		return EXIT_FAILURE;
+	}
+
+	spng_ctx_free(lsp_ctx);
+	fclose(fp_png);
+
+	if (argc == 3) {
+		strcpy(file_argb, argv[2]);
+	} else { // in same directory as png
+		strcpy(file_argb, argv[1]);
+		strcpy(&file_argb[strlen(file_argb) - 4], ".argb");
+	}
+
+#if CHECK_OW == 1
+	if (fp_argb = fopen(file_argb, "r")) {
+		printf("Output file '%s' exists, aborting.\n", file_argb);
+		fclose(fp_argb);
+		return EXIT_FAILURE;
+	}
+#endif
+
+	if (!(fp_argb = fopen(file_argb, "wb"))) {
+		printf("Can't open output file '%s'\n", file_argb);
+		return EXIT_FAILURE;
+	}
+
+	argb.px = malloc(n*sizeof(argb_px_t));
+
+	for (uint64_t i = 0; i < n; i++) {
+		argb.px[i].a = png_px[i].a;
+		if (argb.px[i].a < 0xFF) {
+			argb.flags |= ARGB_FLAG_TRANSPARENCY;
+		}
+		argb.px[i].r = png_px[i].r;
+		argb.px[i].g = png_px[i].g;
+		argb.px[i].b = png_px[i].b;
+	}
+
+	free(png_px);
+
+	memcpy(argb.magic, argb_magic, strlen(argb_magic));
+
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+	argb.nx    = bswap_32(argb.nx);
+	argb.ny    = bswap_32(argb.ny);
+	argb.flags = bswap_32(argb.flags);
+#endif
+
+	fwrite(&argb, sizeof(uint8_t), 128, fp_argb);
+	fwrite(argb.px, sizeof(argb_px_t), n, fp_argb);
+
+	fclose(fp_argb);
+	free(argb.px);
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Comparison video as announced:
https://www.youtube.com/watch?v=JbJaZhiyz-0

Probably now limited by rendering other stuff (bg image -> could also use ARGB now, also backdrop, etc.).

PS quick note:
Something is broken with your recent commit [4b4838da03745c73b29c524fd693f1d66f3b26bb](https://github.com/aldostools/webMAN-MOD/commit/4b4838da03745c73b29c524fd693f1d66f3b26bb)
Crashes instantly upon opening even with clean/removed wmtmp.