### PR TITLE
Removed space between -I/-L and includedir/libdir to align with the commonly used syntax.

### DIFF
--- a/_Projects_/netiso/Makefile
+++ b/_Projects_/netiso/Makefile
@@ -9,7 +9,7 @@ LIBSTUB_DIR		= $(ROOT_PATH)/lib
 PRX_DIR			= .
 INSTALL			= cp
 PEXPORTPICKUP		= ppu-lv2-prx-exportpickup
-PRX_LDFLAGS_EXTRA	= -L $(ROOT_PATH)/lib -Wl,--strip-unused-data
+PRX_LDFLAGS_EXTRA	= -L$(ROOT_PATH)/lib -Wl,--strip-unused-data
 
 CRT_HEAD                += $(shell ppu-lv2-gcc -print-file-name'='ecrti.o)
 CRT_HEAD                += $(shell ppu-lv2-gcc -print-file-name'='crtbegin.o)

--- a/_Projects_/rawseciso/Makefile
+++ b/_Projects_/rawseciso/Makefile
@@ -9,7 +9,7 @@ LIBSTUB_DIR		= ../lib
 PRX_DIR			= .
 INSTALL			= cp
 PEXPORTPICKUP		= ppu-lv2-prx-exportpickup
-PRX_LDFLAGS_EXTRA	= -L ../lib -Wl,--strip-unused-data
+PRX_LDFLAGS_EXTRA	= -L../lib -Wl,--strip-unused-data
 
 CRT_HEAD                += $(shell ppu-lv2-gcc -print-file-name'='ecrti.o)
 CRT_HEAD                += $(shell ppu-lv2-gcc -print-file-name'='crtbegin.o)

--- a/_Projects_/slaunch/Makefile
+++ b/_Projects_/slaunch/Makefile
@@ -11,9 +11,9 @@ CRT_HEAD += $(shell ppu-lv2-gcc -print-file-name'='ecrtn.o)
 ROOT_PATH = ../..
 
 PPU_SRCS = $(ROOT_PATH)/libc.c mem.c misc.c argb_dec.c png_dec.c jpg_dec.c blitting.c slaunch.c
-PPU_INCDIRS	= -I $(ROOT_PATH)/vsh
+PPU_INCDIRS	= -I$(ROOT_PATH)/vsh
 PPU_PRX_TARGET = slaunch.prx
-PPU_PRX_LDFLAGS = -L $(ROOT_PATH)/lib -Wl,--strip-unused-data
+PPU_PRX_LDFLAGS = -L$(ROOT_PATH)/lib -Wl,--strip-unused-data
 PPU_PRX_STRIP_FLAGS = -s
 PPU_PRX_LDLIBS 	+= -lfs_stub -lnet_stub -lrtc_stub -lio_stub -lnetctl_stub -ljpgdec_stub \
                    -lstdc_export_stub \

--- a/_Projects_/vsh_menu/Makefile
+++ b/_Projects_/vsh_menu/Makefile
@@ -11,9 +11,9 @@ CRT_HEAD += $(shell ppu-lv2-gcc -print-file-name'='ecrtn.o)
 ROOT_PATH = ../..
 
 PPU_SRCS = $(ROOT_PATH)/libc.c mem.c misc.c png_dec.c blitting.c main.c
-PPU_INCDIRS	= -I $(ROOT_PATH)/vsh
+PPU_INCDIRS	= -I$(ROOT_PATH)/vsh
 PPU_PRX_TARGET = wm_vsh_menu.prx
-PPU_PRX_LDFLAGS = -L $(ROOT_PATH)/lib -Wl,--strip-unused-data
+PPU_PRX_LDFLAGS = -L$(ROOT_PATH)/lib -Wl,--strip-unused-data
 PPU_PRX_STRIP_FLAGS = -s
 PPU_PRX_LDLIBS 	+= -lfs_stub -lnet_stub -lrtc_stub -lio_stub -lnetctl_stub \
                    -lstdc_export_stub \

--- a/_Projects_/wm_proxy/Makefile
+++ b/_Projects_/wm_proxy/Makefile
@@ -9,7 +9,7 @@ LIBSTUB_DIR		= ./lib
 PRX_DIR			= .
 INSTALL			= cp
 PEXPORTPICKUP		= ppu-lv2-prx-exportpickup
-PRX_LDFLAGS_EXTRA	= -L ./lib -Wl,--strip-unused-data
+PRX_LDFLAGS_EXTRA	= -L./lib -Wl,--strip-unused-data
 
 CRT_HEAD                += $(shell ppu-lv2-gcc -print-file-name'='ecrti.o)
 CRT_HEAD                += $(shell ppu-lv2-gcc -print-file-name'='crtbegin.o)


### PR DESCRIPTION
The space made me think it's the culprit giving linking errors while it was the space between `-Wl,` and `--strip-unused-data`.

Also makes the compiler/linker go through less args, tiny OCD optimization.