### PR TITLE
ps3netsrv: linux: Create new files with mode 0666

### DIFF
--- a/_Projects_/ps3netsrv/src/compat.c
+++ b/_Projects_/ps3netsrv/src/compat.c
@@ -352,7 +352,7 @@ file_t open_file(const char *path, int oflag)
 	if(!path)
 		return INVALID_FD;
 
-	return open(path, oflag);
+	return open(path, oflag, 0666);
 }
 
 int close_file(file_t fd)


### PR DESCRIPTION
Prior to this change, files would be created with modes like '---x-----t', which may prohibit reading the file back without manually changing the permissions.

This change forces all files to be created as mode '0666' (rwxrwxwrx) which will then obey the service's umask, as set (e.g.) by a systemd service:
[Service]
UMask=002

Ref: https://stackoverflow.com/a/2245212/1063497

Would also probably fix #115