### PR TITLE
Improved ROS patch algorithm

### DIFF
--- a/include/feat/rospatch.h
+++ b/include/feat/rospatch.h
@@ -7,220 +7,220 @@ static bool ros_patching = false;
 
 static int sys_storage_write(int fd, u32 start_sector, u32 sectors, void *bounce_buf, u32 *sectors_read)
 {
-	system_call_7(603, fd, 0, start_sector, sectors, (u64)(u32) bounce_buf, (u64)(u32) sectors_read, FLASH_FLAGS);
-	return (int)p1;
+    system_call_7(603, fd, 0, start_sector, sectors, (u64)(u32) bounce_buf, (u64)(u32) sectors_read, FLASH_FLAGS);
+    return (int)p1;
 }
 
 static void sys_ss_get_cache_of_flash_ext_flag(u8 *flag)
 {
-	system_call_1(874, (u64)(u32) flag);
+    system_call_1(874, (u64)(u32) flag);
 }
 
 static bool is_nor(void)
 {
-	u8 flag = 0;
-	sys_ss_get_cache_of_flash_ext_flag(&flag);
-	return !(1 & flag);
+    u8 flag = 0;
+    sys_ss_get_cache_of_flash_ext_flag(&flag);
+    return !(1 & flag);
 }
 
 // TODO: resolve unused "full", add missing bool usb_debug
 static int patch_ros(const char *patch_file, u8 *mem, int conn_s, u8 ros, bool full)
 {
-	send(conn_s, "<p>Patch process start</p>", 26, 0);
-	if(ros_patching || file_size(patch_file) != 7340000) {BEEP3; return FAILED;}
+    send(conn_s, "<p>Patch process start</p>", 26, 0);
+    if(ros_patching || file_size(patch_file) != 7340000) {BEEP3; return FAILED;}
 
-	const char ROS_HEADER[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	                            0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-								0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6F, 0xFF, 0xE0 };
+    const char ROS_HEADER[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6F, 0xFF, 0xE0 };
 
-	ros_patching = true; // prevent call this function while processing
+    ros_patching = true; // prevent call this function while processing
 
-	// Redirect all flash reads and writes to dev_usb000
-	// USB storage is supposed to contain a flash dump written directly from the beginning
-	// i.e. dd if=nor_dump.bin of=/dev/sde     or     Win32DiskImager / ImageUSB for Windows
-	bool usb_debug = true;
+    // Redirect all flash reads and writes to dev_usb000
+    // USB storage is supposed to contain a flash dump written directly from the beginning
+    // i.e. dd if=nor_dump.bin of=/dev/sde     or     Win32DiskImager / ImageUSB for Windows
+    bool usb_debug = true;
 
-	// open nofsm_patch.bin
-	int fd, ret = CELL_OK;
-	if(cellFsOpen(patch_file, CELL_FS_O_RDONLY, &fd, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+    // open nofsm_patch.bin
+    int fd, ret = CELL_OK;
+    if(cellFsOpen(patch_file, CELL_FS_O_RDONLY, &fd, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
 
-	// open flash
-	const u32 flags = 0x01000000;
-	u32 offset1, offset2, metldr_sec = 0x4, r; // metldr is always at sector 4, offset 0x20
-	u64 start_ros0, start_ros1; // NOR ros0 = 0xC0000, ros1 = 0x7C0000
-	sys_device_handle_t flash_id;
+    // open flash
+    const u32 flags = 0x01000000;
+    u32 offset1, offset2, metldr_sec = 0x4, r; // metldr is always at sector 4, offset 0x20
+    u64 start_ros0, start_ros1; // NOR ros0 = 0xC0000, ros1 = 0x7C0000
+    sys_device_handle_t flash_id;
 
-	// TODO: Add check for minver < 3.60
+    // TODO: Add check for minver < 3.60
 
-	if(is_nor())
-	{
-		// Open NOR flash
-		send(conn_s, "<p>Opening NOR...</p>", 22, 0);
-		if(!usb_debug)
-		{
-			if(sys_storage_open(FLASH_DEVICE_NOR, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
-		}
-		else
-		{
-			send(conn_s, "<p>USB debug enabled</p>", 24, 0);
-			if(sys_storage_open(0x10300000000000AULL, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
-		}
-		offset1 = 0x10;
-		offset2 = 0x10;
-		start_ros0 = 0x600;
-		start_ros1 = 0x3e00;
-	}
-	else
-	{
-		// Open NAND flash
-		send(conn_s, "<p>Opening NAND...</p>", 23, 0);
-		if(!usb_debug)
-		{
-			if(sys_storage_open(FLASH_DEVICE_NAND, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
-		}
-		else
-		{
-			send(conn_s, "<p>USB debug enabled</p>", 24, 0);
-			if(sys_storage_open(0x10300000000000AULL, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
-		}
-		offset1 = 0x30;
-		offset2 = 0x20;
-		start_ros0 = 0x400;
-		start_ros1 = 0x3c00;
-	}
+    if(is_nor())
+    {
+        // Open NOR flash
+        send(conn_s, "<p>Opening NOR...</p>", 22, 0);
+        if(!usb_debug)
+        {
+            if(sys_storage_open(FLASH_DEVICE_NOR, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+        }
+        else
+        {
+            send(conn_s, "<p>USB debug enabled</p>", 24, 0);
+            if(sys_storage_open(0x10300000000000AULL, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+        }
+        offset1 = 0x10;
+        offset2 = 0x10;
+        start_ros0 = 0x600;
+        start_ros1 = 0x3e00;
+    }
+    else
+    {
+        // Open NAND flash
+        send(conn_s, "<p>Opening NAND...</p>", 23, 0);
+        if(!usb_debug)
+        {
+            if(sys_storage_open(FLASH_DEVICE_NAND, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+        }
+        else
+        {
+            send(conn_s, "<p>USB debug enabled</p>", 24, 0);
+            if(sys_storage_open(0x10300000000000AULL, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+        }
+        offset1 = 0x30;
+        offset2 = 0x20;
+        start_ros0 = 0x400;
+        start_ros1 = 0x3c00;
+    }
 
-	const int sec_size = 0x200; // 512 bytes
+    const int sec_size = 0x200; // 512 bytes
 
-	char read_buf[sec_size + 0x30]; // length of one sector + something extra for more room to play
-	memset(&read_buf, 0, sec_size + 0x30);
+    char read_buf[sec_size + 0x30]; // length of one sector + something extra for more room to play
+    memset(&read_buf, 0, sec_size + 0x30);
 
-	char *item_name = ((char *) read_buf) + 0x20;
+    char *item_name = ((char *) read_buf) + 0x20;
 
-	// abort if metldr is not found at metldr_sec (or if metldr.2 is found)
-	sys_storage_read(flash_id, 0, metldr_sec, 1, read_buf, &r, FLASH_FLAGS);
-	if(!(IS(item_name, "metldr") && !IS(item_name, "metldr.2")))
-	{
-		send(conn_s, "<p>Wrong metldr version!</p>", 28, 0);
-		ret = FAILED; goto exit_ros;
-	}
+    // abort if metldr is not found at metldr_sec (or if metldr.2 is found)
+    sys_storage_read(flash_id, 0, metldr_sec, 1, read_buf, &r, FLASH_FLAGS);
+    if(!(IS(item_name, "metldr") && !IS(item_name, "metldr.2")))
+    {
+        send(conn_s, "<p>Wrong metldr version!</p>", 28, 0);
+        ret = FAILED; goto exit_ros;
+    }
 
-	// Prepare ROS overlays
-	for(int cur_ros = 0; cur_ros <= 1; cur_ros++)
-	{
-		send(conn_s, "<p>Preparing ROS overlay...</p>", 31, 0);
-		int fd_overlay;
-		int curr_offset;
-		if(cur_ros == 0)
-		{
-			if(cellFsOpen(ROS0_overlay_path, CELL_FS_O_CREAT|CELL_FS_O_WRONLY|CELL_FS_O_TRUNC, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
-			curr_offset = offset1;
-		}
-		else
-		{
-			if(cellFsOpen(ROS1_overlay_path, CELL_FS_O_CREAT|CELL_FS_O_WRONLY|CELL_FS_O_TRUNC, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
-			curr_offset = offset2;
-		}
+    // Prepare ROS overlays
+    for(int cur_ros = 0; cur_ros <= 1; cur_ros++)
+    {
+        send(conn_s, "<p>Preparing ROS overlay...</p>", 31, 0);
+        int fd_overlay;
+        int curr_offset;
+        if(cur_ros == 0)
+        {
+            if(cellFsOpen(ROS0_overlay_path, CELL_FS_O_CREAT|CELL_FS_O_WRONLY|CELL_FS_O_TRUNC, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+            curr_offset = offset1;
+        }
+        else
+        {
+            if(cellFsOpen(ROS1_overlay_path, CELL_FS_O_CREAT|CELL_FS_O_WRONLY|CELL_FS_O_TRUNC, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+            curr_offset = offset2;
+        }
 
-		//Write ROS header
-		u64 n_written;
-		memcpy(&read_buf, ROS_HEADER, sizeof(ROS_HEADER));
-		
-		// Special care for NAND based models
-		if(!is_nor())
-		{
-			// Preserve first 16 bytes of ROS0
-			char read_buf2[sec_size];
-			sys_storage_read(flash_id, 0, start_ros0, 1, &read_buf2, &r, FLASH_FLAGS);
-			memcpy(&read_buf, &read_buf2, 16);
+        //Write ROS header
+        u64 n_written;
+        memcpy(&read_buf, ROS_HEADER, sizeof(ROS_HEADER));
+        
+        // Special care for NAND based models
+        if(!is_nor())
+        {
+            // Preserve first 16 bytes of ROS0
+            char read_buf2[sec_size];
+            sys_storage_read(flash_id, 0, start_ros0, 1, &read_buf2, &r, FLASH_FLAGS);
+            memcpy(&read_buf, &read_buf2, 16);
 
-			if(cur_ros == 1)
-			{
-				// Zero fill 16 bytes at offset 0x10 in ROS1 header for NAND
-				memset(&read_buf[0x10], 0x00, 16);
-			}
-		}
+            if(cur_ros == 1)
+            {
+                // Zero fill 16 bytes at offset 0x10 in ROS1 header for NAND
+                memset(&read_buf[0x10], 0x00, 16);
+            }
+        }
 
-		cellFsWrite(fd_overlay, &read_buf[sizeof(ROS_HEADER) - curr_offset], curr_offset, &n_written);
-		// TODO: Checks for number of actually written bytes/sectors
+        cellFsWrite(fd_overlay, &read_buf[sizeof(ROS_HEADER) - curr_offset], curr_offset, &n_written);
+        // TODO: Checks for number of actually written bytes/sectors
 
-		//Copy noFSM patch
-		u64 n_read;
-		for(int sector = 0; sector <= 0x37FF; sector++)
-		{
-			// Read 1 sector
-			cellFsReadWithOffset(fd, sector * sec_size, &read_buf, sec_size, &n_read);
+        //Copy noFSM patch
+        u64 n_read;
+        for(int sector = 0; sector <= 0x37FF; sector++)
+        {
+            // Read 1 sector
+            cellFsReadWithOffset(fd, sector * sec_size, &read_buf, sec_size, &n_read);
 
-			if(sector == 0x37FF)
-			{
-				if(curr_offset < 0x20)
-				{
-					// If we are at the very last sector of noFSM patch and the offset isn't 32 bytes or more.
-					// It means that the last noFSM read wasn't able to get a whole sector. (noFSM patch is always 32 bytes shorter)
-					// We are supposed to add padding so it's aligned exactly to 0x3800 sectors
-					char padding_val = is_nor() ? 0xFF: 0x00;
+            if(sector == 0x37FF)
+            {
+                if(curr_offset < 0x20)
+                {
+                    // If we are at the very last sector of noFSM patch and the offset isn't 32 bytes or more.
+                    // It means that the last noFSM read wasn't able to get a whole sector. (noFSM patch is always 32 bytes shorter)
+                    // We are supposed to add padding so it's aligned exactly to 0x3800 sectors
+                    char padding_val = is_nor() ? 0xFF: 0x00;
 
-					memset(&read_buf[n_read], padding_val, sec_size - n_read);
-					cellFsWrite(fd_overlay, read_buf, sec_size - (0x20 - curr_offset), &n_written);
-				}
-				
-				if(curr_offset >= 0x20)
-				{
-					// Write the last incomplete noFSM sector
-					// Write less if the offset is longer than 0x20
-					cellFsWrite(fd_overlay, read_buf, n_read - (curr_offset - 0x20), &n_written);
-				}
-			}
-			else
-			{
-				cellFsWrite(fd_overlay, read_buf, sec_size, &n_written);
-			}
-		}
+                    memset(&read_buf[n_read], padding_val, sec_size - n_read);
+                    cellFsWrite(fd_overlay, read_buf, sec_size - (0x20 - curr_offset), &n_written);
+                }
+                
+                if(curr_offset >= 0x20)
+                {
+                    // Write the last incomplete noFSM sector
+                    // Write less if the offset is longer than 0x20
+                    cellFsWrite(fd_overlay, read_buf, n_read - (curr_offset - 0x20), &n_written);
+                }
+            }
+            else
+            {
+                cellFsWrite(fd_overlay, read_buf, sec_size, &n_written);
+            }
+        }
 
-		send(conn_s, "<p>ROS overlay prepared</p>", 27, 0);
-		cellFsClose(fd_overlay);
-		// TODO: Check that newly written overlay file is indeed 0x3800 sectors long, 7 340 032 bytes
-	}
+        send(conn_s, "<p>ROS overlay prepared</p>", 27, 0);
+        cellFsClose(fd_overlay);
+        // TODO: Check that newly written overlay file is indeed 0x3800 sectors long, 7 340 032 bytes
+    }
 
-	// Write ROS overlays to flash
-	for(int cur_ros = 0; cur_ros <= 1; cur_ros++)
-	{
-		send(conn_s, "<p>Writing ROS overlay...</p>", 29, 0);
-		int fd_overlay;
-		int curr_ros_start_sec;
-		if(cur_ros == 0)
-		{
-			if(cellFsOpen(ROS0_overlay_path, CELL_FS_O_RDONLY, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
-			curr_ros_start_sec = start_ros0;
-		}
-		else
-		{
-			if(cellFsOpen(ROS1_overlay_path, CELL_FS_O_RDONLY, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
-			curr_ros_start_sec = start_ros1;
-		}
+    // Write ROS overlays to flash
+    for(int cur_ros = 0; cur_ros <= 1; cur_ros++)
+    {
+        send(conn_s, "<p>Writing ROS overlay...</p>", 29, 0);
+        int fd_overlay;
+        int curr_ros_start_sec;
+        if(cur_ros == 0)
+        {
+            if(cellFsOpen(ROS0_overlay_path, CELL_FS_O_RDONLY, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+            curr_ros_start_sec = start_ros0;
+        }
+        else
+        {
+            if(cellFsOpen(ROS1_overlay_path, CELL_FS_O_RDONLY, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+            curr_ros_start_sec = start_ros1;
+        }
 
-		u64 n_read;
-		u32 n_written;
-		for(int sector = 0; sector <= 0x37FF; sector++)
-		{
-			cellFsReadWithOffset(fd_overlay, sector * sec_size, &read_buf, sec_size, &n_read);
-			sys_storage_write(flash_id, curr_ros_start_sec + sector, 1, (void *) &read_buf, &n_written);
-		}
-		
-		send(conn_s, "<p>ROS overlay written</p>", 26, 0);
-		cellFsClose(fd_overlay);
-	}
+        u64 n_read;
+        u32 n_written;
+        for(int sector = 0; sector <= 0x37FF; sector++)
+        {
+            cellFsReadWithOffset(fd_overlay, sector * sec_size, &read_buf, sec_size, &n_read);
+            sys_storage_write(flash_id, curr_ros_start_sec + sector, 1, (void *) &read_buf, &n_written);
+        }
+        
+        send(conn_s, "<p>ROS overlay written</p>", 26, 0);
+        cellFsClose(fd_overlay);
+    }
 
 
-	// TODO: Verify final ROS hashes.
+    // TODO: Verify final ROS hashes.
 
 exit_ros:
-	// close & exit
-	sys_storage_close(flash_id);
-	cellFsClose(fd);
+    // close & exit
+    sys_storage_close(flash_id);
+    cellFsClose(fd);
 
-	if(ret) {BEEP3} else {BEEP2}
+    if(ret) {BEEP3} else {BEEP2}
 
-	stop_ros = ros_patching = false;
-	return ret;
+    stop_ros = ros_patching = false;
+    return ret;
 }
 #endif //#ifdef PATCH_ROS

--- a/include/feat/rospatch.h
+++ b/include/feat/rospatch.h
@@ -2,170 +2,216 @@
 static bool stop_ros = false;
 static bool ros_patching = false;
 
-static int sys_storage_write(int fd, u32 start_sector, u32 sectors, u8 *bounce_buf, u64 *sectors_read)
+#define ROS0_overlay_path "/dev_hdd0/ros0_overlay.bin"
+#define ROS1_overlay_path "/dev_hdd0/ros1_overlay.bin"
+
+static int sys_storage_write(int fd, u32 start_sector, u32 sectors, void *bounce_buf, u32 *sectors_read)
 {
 	system_call_7(603, fd, 0, start_sector, sectors, (u64)(u32) bounce_buf, (u64)(u32) sectors_read, FLASH_FLAGS);
 	return (int)p1;
 }
 
+static void sys_ss_get_cache_of_flash_ext_flag(u8 *flag)
+{
+	system_call_1(874, (u64)(u32) flag);
+}
+
+static bool is_nor(void)
+{
+	u8 flag = 0;
+	sys_ss_get_cache_of_flash_ext_flag(&flag);
+	return !(1 & flag);
+}
+
+// TODO: resolve unused "full", add missing bool usb_debug
 static int patch_ros(const char *patch_file, u8 *mem, int conn_s, u8 ros, bool full)
 {
+	send(conn_s, "<p>Patch process start</p>", 26, 0);
 	if(ros_patching || file_size(patch_file) != 7340000) {BEEP3; return FAILED;}
+
+	const char ROS_HEADER[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	                            0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+								0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6F, 0xFF, 0xE0 };
 
 	ros_patching = true; // prevent call this function while processing
 
+	// Redirect all flash reads and writes to dev_usb000
+	// USB storage is supposed to contain a flash dump written directly from the beginning
+	// i.e. dd if=nor_dump.bin of=/dev/sde     or     Win32DiskImager / ImageUSB for Windows
+	bool usb_debug = true;
+
 	// open nofsm_patch.bin
-	int fd, pos, ret = CELL_OK;
+	int fd, ret = CELL_OK;
 	if(cellFsOpen(patch_file, CELL_FS_O_RDONLY, &fd, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
 
-	// open flash NOR
+	// open flash
 	const u32 flags = 0x01000000;
-	u32 offset1 = 0x10, offset2 = 0x10, metldr_sec = 0x4, r;
-	u64 read, start_ros0 = 0x600, start_ros1 = 0x3E00; // NOR ros0 = 0xC0010, ros1 = 0x7C0010
+	u32 offset1, offset2, metldr_sec = 0x4, r; // metldr is always at sector 4, offset 0x20
+	u64 start_ros0, start_ros1; // NOR ros0 = 0xC0000, ros1 = 0x7C0000
 	sys_device_handle_t flash_id;
-	if(sys_storage_open(FLASH_DEVICE_NOR, 0, &flash_id, flags) != CELL_OK)
+
+	// TODO: Add check for minver < 3.60
+
+	if(is_nor())
 	{
-		// open flash NAND
-		if(sys_storage_open(FLASH_DEVICE_NAND, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
-		offset1 = 0x30, offset2 = 0x20;
-		//start_ros0 = 0x600;  // NAND ros0 = 0xC0030  / 0x80030
-		//start_ros1 = 0x3E00; //      ros1 = 0x7C0020 / 0x780020
-		metldr_sec = 0x204;    //    metldr = 0x40820  / 0x820
+		// Open NOR flash
+		send(conn_s, "<p>Opening NOR...</p>", 22, 0);
+		if(!usb_debug)
+		{
+			if(sys_storage_open(FLASH_DEVICE_NOR, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+		}
+		else
+		{
+			send(conn_s, "<p>USB debug enabled</p>", 24, 0);
+			if(sys_storage_open(0x10300000000000AULL, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+		}
+		offset1 = 0x10;
+		offset2 = 0x10;
+		start_ros0 = 0x600;
+		start_ros1 = 0x3e00;
+	}
+	else
+	{
+		// Open NAND flash
+		send(conn_s, "<p>Opening NAND...</p>", 23, 0);
+		if(!usb_debug)
+		{
+			if(sys_storage_open(FLASH_DEVICE_NAND, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+		}
+		else
+		{
+			send(conn_s, "<p>USB debug enabled</p>", 24, 0);
+			if(sys_storage_open(0x10300000000000AULL, 0, &flash_id, flags) != CELL_OK) {BEEP3; cellFsClose(fd); ros_patching = false; return FAILED;}
+		}
+		offset1 = 0x30;
+		offset2 = 0x20;
+		start_ros0 = 0x400;
+		start_ros1 = 0x3c00;
 	}
 
 	const int sec_size = 0x200; // 512 bytes
-	int seg_size = full ? 0x40 : 0x80;  // 64 sectors  / 128 sectors
-	int buf_size = seg_size * sec_size; // 32KB (full) / 64KB (default)
 
-	const int header_size = 0x4C0; // 3 sectors
-	u32 patch_size = full ? 0x3800 : 0x2C80; // 7MB vs 5.5MB => 0x700000 vs 0x590000 // min clean: 0x2F80 =>0x5F0000
-	bool write_data = true;
+	char read_buf[sec_size + 0x30]; // length of one sector + something extra for more room to play
+	memset(&read_buf, 0, sec_size + 0x30);
 
-	u8 *backup  = mem; // full only
-	u8 *sectors = mem + (full ? buf_size : 0);
-	u8 *written = sectors    + buf_size;
-	char *item_name = ((char *)sectors) + 0x20;
+	char *item_name = ((char *) read_buf) + 0x20;
 
-	u32 sec, ros_sec, patch_offset; u8 *sector = sectors;
-
-retry_metldr:
-	// abort if metldr is not found at 0x820 NOR / 0x40820 NAND (or if metldr.2 is found)
-	sys_storage_read(flash_id, 0, metldr_sec, 1, sector, &r, FLASH_FLAGS);
-	if(!IS(item_name, "metldr") || IS(item_name, "metldr.2"))
+	// abort if metldr is not found at metldr_sec (or if metldr.2 is found)
+	sys_storage_read(flash_id, 0, metldr_sec, 1, read_buf, &r, FLASH_FLAGS);
+	if(!(IS(item_name, "metldr") && !IS(item_name, "metldr.2")))
 	{
-		// try to find metldr in NOR offset
-		if(metldr_sec == 0x204) {metldr_sec = 0x4; goto retry_metldr;}
+		send(conn_s, "<p>Wrong metldr version!</p>", 28, 0);
 		ret = FAILED; goto exit_ros;
 	}
 
-patch_ros:
-	if(stop_ros) {ret = FAILED; goto exit_ros;}
-
-	if(ros == 1)
+	// Prepare ROS overlays
+	for(int cur_ros = 0; cur_ros <= 1; cur_ros++)
 	{
-		offset1 = offset2;
-		start_ros0 = start_ros1;
-
-		// notify start patching ROS1
-		send(conn_s, "<p>Patching ROS1:", 17, 0);
-	}
-	else // ros == 0 || ros >= 2
-	{
-		// notify start patching ROS0
-		send(conn_s, "<p>Patching ROS0:", 17, 0);
-	}
-	BEEP1;
-
-retry_ros:
-	// read first 3 sectors of ros0 to get first 0x10 (NOR) or 0x30 bytes (NAND) and check for "sdk_version"
-	sys_storage_read(flash_id, 0, start_ros0, 3, sectors, &r, FLASH_FLAGS);	
-
-	// check for "sdk_version" to verify that it is a valid ros0 file table
-	for(pos = offset1; pos < header_size; pos += 0x30)
-		if(IS(item_name + pos, "sdk_version")) break;
-	if(pos >= header_size)
-	{
-		// try to find ROS in 0x80030 / 0x780020 (NAND)
-		if(start_ros0 == 0x600) {start_ros0 = 0x400, start_ros1 = 0x3C00; goto retry_ros;}
-		ret = FAILED; goto exit_ros;
-	}
-
-	// backup first sector before write
-	if(full) memcpy(backup, sector, sec_size);
-
-	// read first sector nofsm_patch.bin & write to ros0 / ros1
-	if(cellFsReadWithOffset(fd, 0, (void *)(sector + offset1), sec_size - offset1, &read) != CELL_FS_SUCCEEDED) {ret = FAILED; goto exit_ros;}
-	sys_storage_write(flash_id, start_ros0, 1, sector, &read);
-
-	// verify written data
-	if(full)
-	{
-		sys_storage_read(flash_id, 0, start_ros0, 1, written, &r, FLASH_FLAGS);
-		if(memcmp(sector, written, sec_size))
+		send(conn_s, "<p>Preparing ROS overlay...</p>", 31, 0);
+		int fd_overlay;
+		int curr_offset;
+		if(cur_ros == 0)
 		{
-			// restore original sector
-			sys_storage_write(flash_id, start_ros0, 1, backup, &read);
-			ret = FAILED; goto exit_ros;
+			if(cellFsOpen(ROS0_overlay_path, CELL_FS_O_CREAT|CELL_FS_O_WRONLY|CELL_FS_O_TRUNC, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+			curr_offset = offset1;
 		}
-	}
-
-	seg_size = 0x40;  // 64 sectors
-	buf_size = seg_size * sec_size; // 32KB
-
-	for(sec = 1; sec < patch_size; sec += seg_size)
-	{
-		if(stop_ros) {ret = FAILED; goto exit_ros;}
-
-		// prevent cross ROS boundaries
-		if(sec + seg_size >= 0x3800)
+		else
 		{
-			seg_size = (0x3800 - sec - 1);  // 62 sectors
-			buf_size = seg_size * sec_size; // 62 * 0x200 bytes = 0x7C00 = bytes
+			if(cellFsOpen(ROS1_overlay_path, CELL_FS_O_CREAT|CELL_FS_O_WRONLY|CELL_FS_O_TRUNC, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+			curr_offset = offset2;
 		}
 
-		patch_offset = (sec * sec_size) - offset1;
-		ros_sec = start_ros0 + sec;
-
-		// read nofsm patch
-		if(cellFsReadWithOffset(fd, patch_offset, (void *)sectors, buf_size, &read) != CELL_FS_SUCCEEDED) {ret = FAILED; goto exit_ros;}
-
-		// backup sectors before write
-		if(full)
+		//Write ROS header
+		u64 n_written;
+		memcpy(&read_buf, ROS_HEADER, sizeof(ROS_HEADER));
+		
+		// Special care for NAND based models
+		if(!is_nor())
 		{
-			sys_storage_read(flash_id, 0, ros_sec, seg_size, backup, &r, FLASH_FLAGS);
+			// Preserve first 16 bytes of ROS0
+			char read_buf2[sec_size];
+			sys_storage_read(flash_id, 0, start_ros0, 1, &read_buf2, &r, FLASH_FLAGS);
+			memcpy(&read_buf, &read_buf2, 16);
 
-			// verify if needs to write segment
-			write_data = (memcmp(sectors, backup, buf_size) != CELL_OK);
-		}
-
-		if(write_data)
-		{
-			// write patch to ros0 / ros1
-			sys_storage_write(flash_id, ros_sec, seg_size, sectors, &read);
-
-			// verify written data
-			if(full)
+			if(cur_ros == 1)
 			{
-				sys_storage_read(flash_id, 0, ros_sec, seg_size, written, &r, FLASH_FLAGS);
-				if(memcmp(sectors, written, buf_size))
-				{
-					// restore original sectors
-					sys_storage_write(flash_id, ros_sec, seg_size, backup, &read);
-					ret = FAILED; goto exit_ros;
-				}
+				// Zero fill 16 bytes at offset 0x10 in ROS1 header for NAND
+				memset(&read_buf[0x10], 0x00, 16);
 			}
 		}
 
-		// show progress every 64KB
-		if(sec % 80 == 1) send(conn_s, ".", 1, 0);
+		cellFsWrite(fd_overlay, &read_buf[sizeof(ROS_HEADER) - curr_offset], curr_offset, &n_written);
+		// TODO: Checks for number of actually written bytes/sectors
+
+		//Copy noFSM patch
+		u64 n_read;
+		for(int sector = 0; sector <= 0x37FF; sector++)
+		{
+			// Read 1 sector
+			cellFsReadWithOffset(fd, sector * sec_size, &read_buf, sec_size, &n_read);
+
+			if(sector == 0x37FF)
+			{
+				if(curr_offset < 0x20)
+				{
+					// If we are at the very last sector of noFSM patch and the offset isn't 32 bytes or more.
+					// It means that the last noFSM read wasn't able to get a whole sector. (noFSM patch is always 32 bytes shorter)
+					// We are supposed to add padding so it's aligned exactly to 0x3800 sectors
+					char padding_val = is_nor() ? 0xFF: 0x00;
+
+					memset(&read_buf[n_read], padding_val, sec_size - n_read);
+					cellFsWrite(fd_overlay, read_buf, sec_size - (0x20 - curr_offset), &n_written);
+				}
+				
+				if(curr_offset >= 0x20)
+				{
+					// Write the last incomplete noFSM sector
+					// Write less if the offset is longer than 0x20
+					cellFsWrite(fd_overlay, read_buf, n_read - (curr_offset - 0x20), &n_written);
+				}
+			}
+			else
+			{
+				cellFsWrite(fd_overlay, read_buf, sec_size, &n_written);
+			}
+		}
+
+		send(conn_s, "<p>ROS overlay prepared</p>", 27, 0);
+		cellFsClose(fd_overlay);
+		// TODO: Check that newly written overlay file is indeed 0x3800 sectors long, 7 340 032 bytes
 	}
 
-	// write ros1 if ros0 succeeded and should write both ros areas
-	if((ret == CELL_OK) && (start_ros0 != start_ros1) && (ros >= 2))
+	// Write ROS overlays to flash
+	for(int cur_ros = 0; cur_ros <= 1; cur_ros++)
 	{
-		ros = 1;
-		goto patch_ros;
+		send(conn_s, "<p>Writing ROS overlay...</p>", 29, 0);
+		int fd_overlay;
+		int curr_ros_start_sec;
+		if(cur_ros == 0)
+		{
+			if(cellFsOpen(ROS0_overlay_path, CELL_FS_O_RDONLY, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+			curr_ros_start_sec = start_ros0;
+		}
+		else
+		{
+			if(cellFsOpen(ROS1_overlay_path, CELL_FS_O_RDONLY, &fd_overlay, NULL, 0) != CELL_FS_SUCCEEDED) {BEEP3; ros_patching = false; return FAILED;}
+			curr_ros_start_sec = start_ros1;
+		}
+
+		u64 n_read;
+		u32 n_written;
+		for(int sector = 0; sector <= 0x37FF; sector++)
+		{
+			cellFsReadWithOffset(fd_overlay, sector * sec_size, &read_buf, sec_size, &n_read);
+			sys_storage_write(flash_id, curr_ros_start_sec + sector, 1, (void *) &read_buf, &n_written);
+		}
+		
+		send(conn_s, "<p>ROS overlay written</p>", 26, 0);
+		cellFsClose(fd_overlay);
 	}
+
+
+	// TODO: Verify final ROS hashes.
 
 exit_ros:
 	// close & exit
@@ -178,4 +224,3 @@ exit_ros:
 	return ret;
 }
 #endif //#ifdef PATCH_ROS
-


### PR DESCRIPTION
After comparing the previous algorithm to the latest version of bgtoolset, I found a few differences that should now make it a working solution. Most of the checks were reimplemented for VSH memory limitations, the rest is in TODOs.

Currently only tested on CECHK (NOR model, CFW 4.84 DEX), with USB flash drive as the target device to be patched. Using that, I was able to verify that both NOR and NAND modes don't corrupt flash contents in any way (at least PyPS3checker can't detect it).

Before patching (NOR):

    ******* Checking CoreOS_region *******
    009.01   ROS0 Header : OK
    009.02   ROS0 Hash : OK
      Size = 0x6FFFE0
      MD5 = 2C6791BAC0978B921CACAEBB1E827743
      Version = 4.89 CEX/SEX OFW/HFW

    009.03   ROS0 unused 0xFF Filled Area : OK
    009.04   ROS1 Header : OK
    009.05   ROS1 Hash : OK
      Size = 0x6FFFE0
      MD5 = 8F4A63DC20F1EB54168478C814DF80C1
      Version = 4.87 CEX/SEX OFW/HFW

    009.06   ROS1 unused 0xFF Filled Area : OK

    Total number of checks = 155
    Number of dangers = 0
    Number of warnings = 0

After patching (NOR):

    ******* Checking CoreOS_region *******
    009.01   ROS0 Header : OK
    009.02   ROS0 Hash : OK
      Size = 0x6FFFE0
      MD5 = B9FEB4432ADB086D890472AB29B663A9
      Version = 4.89 CEX Patched (Evilnat based)

    009.03   ROS0 unused 0xFF Filled Area : OK
    009.04   ROS1 Header : OK
    009.05   ROS1 Hash : OK
      Size = 0x6FFFE0
      MD5 = B9FEB4432ADB086D890472AB29B663A9
      Version = 4.89 CEX Patched (Evilnat based)

    009.06   ROS1 unused 0xFF Filled Area : OK

    Total number of checks = 155
    Number of dangers = 0
    Number of warnings = 0


Changes:
- Removed half/full write modes (not really sure what it does, so I couldn't reimplement it)
- Added flag to redirect all reads and writes to /dev_usb000/ (write NOR/NAND dump to USB flash drive in order to use it)
- ROS offsets are now aligned to sector size boundary
- ROS patches (or "overlays") are prepared as files on HDD before they are written (bypass RAM limitations)
- Preallocated memory segment is now unused
- Added faster check for NOR vs NAND (same one used by bgtoolset)

TODO:
- Add minver check for < 3.60
- Add sanity checks for every read and write return values
- Check that newly written overlay file is indeed 0x3800 sectors long, 7 340 032 bytes
- Verify ROS contents before and after writing them to flash

Credits:
- bguerville (for reference implementation in bgtoolset)
- TheRouletteBoi (for help with PS3 Debugger)
- TobinPS (for help with DEX firmwares and debugging in general)