### PR TITLE
fix mounting /app_home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+[Oo]bjs/
+webftp_server.prx
+webftp_server.sprx
+webftp_server.sym
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/include/setup.h
+++ b/include/setup.h
@@ -391,7 +391,7 @@ static void setup_parse_settings(char *param)
 	get_param("uacc=", webman_config->uaccount, param, 8);
 	#endif
 
-	if(IS_MARKED("hm=")) webman_config->homeb = 1;
+	webman_config->homeb = IS_MARKED("hm=1");
 
 	get_param("hurl=", webman_config->home_url, param, 255);
 #endif

--- a/main.c
+++ b/main.c
@@ -533,11 +533,7 @@ static void wwwd_thread(u64 arg)
 	sys_ppu_thread_create(&thread_id_poll, poll_thread, (u64)webman_config->poll, THREAD_PRIO_POLL, THREAD_STACK_SIZE_POLL_THREAD, SYS_PPU_THREAD_CREATE_JOINABLE, THREAD_NAME_POLL);
 
 	#ifdef COBRA_ONLY
-	// mount custom app in /app_home/PS3_GAME if has USRDIR/EBOOT.BIN
-	if(webman_config->homeb && is_app_dir(webman_config->home_url, "."))
-		set_app_home(webman_config->home_url);
-	else
-		sys_map_path("/app_home", NULL);
+	set_app_home(NULL); // initialize /app_home
 	#endif
 
 	from_reboot = file_exists(WM_NOSCAN_FILE) || file_exists(WM_RELOAD_FILE);


### PR DESCRIPTION
webMAN didn't mount /app_home correctly (it was mounting USRDIR to /app_home. i don't know the reason behind this, but it does not work at all), this commit fixes it


USRDIR-related code has been removed from both map_app_home and set_app_home, the multidisc logic from map_app_home has been commented out (it's completely broken), the conditions in set_app_home have been edited a bit