### PR TITLE
fix multi-game disc support for /app_home

### DIFF
--- a/include/mount/mount_cobra.h
+++ b/include/mount/mount_cobra.h
@@ -148,7 +148,6 @@ mount_again:
 				cobra_mount_ps3_disc_image(cobra_iso_list, iso_parts);
 				sys_ppu_thread_usleep(2500);
 				cobra_send_fake_disc_insert_event();
-				set_bdvd_as_app_home(); // mount (normal) PS3ISO in /app_home
 
 				{
 					get_name(templn, _path, GET_WMTMP);

--- a/include/mount/mount_net.h
+++ b/include/mount/mount_net.h
@@ -134,7 +134,6 @@ if(BETWEEN('0', netid, '4'))
 	{
 		mount_unk = netiso_args.emu_mode = EMU_PS3;
 		if(!is_iso) sprintf(netiso_args.path, "/***PS3***%s", netpath);
-		set_bdvd_as_app_home(); // mount (NET) PS3ISO in /app_home
 	}
 	else if(islike(netpath, "/ROMS"))
 	{

--- a/include/mount/mount_rawiso.h
+++ b/include/mount/mount_rawiso.h
@@ -77,7 +77,6 @@ mounted_ntfs:
 		{
 			get_name(templn, _path, GET_WMTMP);
 			cache_icon0_and_param_sfo(templn);
-			set_bdvd_as_app_home(); // mount (NTFS) PS3ISO in /app_home
 #ifdef FIX_GAME
 			fix_game(_path, title_id, webman_config->fixgame);
 #endif


### PR DESCRIPTION
set_bdvd_as_app_home() was removed because it's redundant (check line 1748)