### PR TITLE
fix GAMEI mounting

### DIFF
--- a/include/mount/mount_misc.h
+++ b/include/mount/mount_misc.h
@@ -17,6 +17,7 @@
 
 			do_umount(false);
 
+			unmap_app_home();
 			sys_map_path(APP_HOME_DIR, _path);
 			if(isDir(PKGLAUNCH_DIR)) sys_map_path(PKGLAUNCH_DIR, _path);
 


### PR DESCRIPTION
regarding GAMEI... (and other app_home issues in general) was it really broken for everyone or just HEN? 

/app_home/PS3_GAME is not getting mapped until /app_home itself is unmapped