### PR TITLE
Auto #2 custom fan curve

### DIFF
--- a/include/poll/fancontrol.h
+++ b/include/poll/fancontrol.h
@@ -27,7 +27,10 @@
 
 static u8 fan_speed = MIN_FANSPEED_8BIT; // 0x33
 static u8 old_fan   = MIN_FANSPEED_8BIT; // 0x33
+static u8 min_fan_speed = MIN_FANSPEED_8BIT; // 0x33
+static u8 max_fan_speed = MAX_FANSPEED_8BIT; // 0xF4
 static u8 max_temp  = 0; //target temperature (0 = FAN_MANUAL/syscon)
+static u8 fan_step_size = 0x05;
 
 #define SC_SET_FAN_POLICY		(389)
 #define SC_GET_FAN_POLICY		(409)
@@ -81,8 +84,9 @@ static void set_fan_speed(u8 new_fan_speed)
 	{
 		{ PS3MAPI_ENABLE_ACCESS_SYSCALL8 }
 
-		u8 min_fan_speed = PERCENT_TO_8BIT(webman_config->minfan); if(min_fan_speed < MIN_FANSPEED_8BIT) min_fan_speed = MIN_FANSPEED_8BIT; // 20%
-		u8 max_fan_speed = PERCENT_TO_8BIT(webman_config->maxfan); if(max_fan_speed < 0x66) max_fan_speed = 0xCC; // 80% (0xCC) if < 40% (0x66)
+		min_fan_speed = PERCENT_TO_8BIT(webman_config->minfan); if(min_fan_speed < MIN_FANSPEED_8BIT) min_fan_speed = MIN_FANSPEED_8BIT; // 20%
+		max_fan_speed = PERCENT_TO_8BIT(webman_config->maxfan); if(max_fan_speed < 0x66) max_fan_speed = 0xCC; // 80% (0xCC) if < 40% (0x66)
+		fan_step_size = (max_fan_speed - min_fan_speed) / MAX(webman_config->dyn_temp - 60, 1); // Anything under 60 is controlled by SYSCON
 
 		if(!max_temp && IS_INGAME) new_fan_speed += PERCENT_TO_8BIT(webman_config->man_ingame); // add in-game increment for manual fan speed
 

--- a/include/poll/fancontrol2.h
+++ b/include/poll/fancontrol2.h
@@ -56,22 +56,24 @@ if(is_ingame_first_15_seconds() == false)
 		{
 			if(delta)
 			{
+				// ORIGINAL CURVE
 				// 60°C=31%, 61°C=33%, 62°C=35%, 63°C=37%, 64°C=39%, 65°C=41%, 66°C=43%, 67°C=45%, 68°C=47%, 69°C=49%
 				// 70°C=50%, 71°C=53%, 72°C=56%, 73°C=59%, 74°C=62%, 75°C=65%, 76°C=68%, 77°C=71%, 78°C=74%, 79°C=77%,+80°C=80%
 
+				// NEW SETTINGS
+				// The fan curve will now follow the settings for Auto, with a target max temp, min fan speed, and max fan speed.
+				// This makes it more adjustable to a user's preference.
+
 				u8 fan_speed = 0;
 
-				if(t1 >= 80)
-					fan_speed = 0xCC; // 80%
-				else if(t1 >= 70)
-					fan_speed = (0x80 + 0x8 * (t1 - 70)); // 50% + 3% per degree
+				if(t1 >= max_temp)
+					fan_speed = max_fan_speed;
 				else if(t1 >= 60)
-					fan_speed = (0x50 + 0x5 * (t1 - 60)); // 30% + 2% per degree
+					fan_speed = (min_fan_speed + fan_step_size * (t1 - 60)); // Adjusted based on target temp and fan min / max.
 
 				if(fan_speed)
 				{
-					u8 min_speed = PERCENT_TO_8BIT(webman_config->minfan);
-					old_fan = MAX(min_speed, fan_speed);
+					old_fan = MAX(min_fan_speed, fan_speed);
 					set_fan_speed(old_fan);
 				}
 				else


### PR DESCRIPTION
I would like to suggest something like this. `Auto #2` only has a hardcoded fan curve at the moment. I find this to be way too aggressive for my liking, and I'm not a fan of the target temp method from `Auto #1` where the fan will be silent then keep ramping up and down excessively once it hits the target temp.

So basically, this is only a linear curve at the moment, using the `Auto at` temp as the max temp, and using the min and max from the fan settings also. It will calculate the step size based on these factors.
___

There are a few things to consider if you would be interested, such as:
* Using it as a new Auto setting such as `Auto #3`, in case people have become accustomed to the hardcoded values
* Using a somewhat exponential curve that starts ramping faster at higher temps
* Possibly still hardcoding higher temps such as 80 degrees Celsius in case someone uses unreasonably low settings
___

If you are interested, I can make changes if necessary. I'd been doing this for my own console, but then I thought it probably makes sense to try contribute if the it would be of interest to the devs.