### PR TITLE
Fix cover syncing from ps3netsrv by preserving title id in remote path

### DIFF
--- a/include/scan/games_covers.h
+++ b/include/scan/games_covers.h
@@ -520,8 +520,10 @@ static void get_default_icon_for_iso(char *icon, const char *param, const char *
 		}
 		else
 		{
-			get_name(icon, file, NO_EXT);
-			int tlen = concat_path(remote_file, param, icon);
+			// preserve title id: Name [BLES-00000].iso -> /net0/PS3ISO/Name [BLES-00000].iso
+			concat_path(remote_file, param, file);
+			// remove extension: /net0/PS3ISO/Name [BLES-00000].iso -> /net0/PS3ISO/Name [BLES-00000]
+			int tlen = remove_ext(remote_file);
 
 			int icon_len = get_name(icon, file, GET_WMTMP); //wmtmp
 


### PR DESCRIPTION
When "Add game-ID to game title" is unchecked, `get_name()` strips the title id from filenames, causing cover matching to fail when syncing from ps3netsrv. Modified the logic to build the remote path directly using `concat_path()` and `remove_ext()` to preserve the title id, ensuring covers sync correctly regardless of the setting.

Fixes https://github.com/aldostools/webMAN-MOD/issues/1299